### PR TITLE
Minor about-this-guide description fixes

### DIFF
--- a/descriptions/markdown/about_this_guide.md
+++ b/descriptions/markdown/about_this_guide.md
@@ -14,45 +14,48 @@ It ranks among the 100 longest worldwide, a remarkable feat after more than fort
 The full description of every metre in this extensive cave system is beyond the scope of this guide. Countless passages saw the light of one or two cavers only, who, running low on energy and motivation, decided that this final indomitable crawl "was it".
 
 Such passages may not be visited again in years, or indeed ever, as the focus of expeditions and individuals shift towards other leads.
-A floor main remain intact, but for the single track of footprints that bears witness to the presence of one explorer.
-Such passages may nonetheless endure within caver's memory, or as an unmarked sinuous offshoot of a larger map or as a name in an online directory.
-Other passages will become highways, passed by many explorers en route to the business end of the cave bearing multiple signs of the cavers' repeated presence: ropes coiled at the bottom of pitch, heavily polished walls of unavoidable constrictions, a constellation of anchors on the walls of large drops.
+A floor may remain intact, but for the single track of footprints that bears witness to the presence of one explorer.
+Such passages may nonetheless endure within the caver's memory, or as an unmarked sinuous offshoot of a larger map or as a name in an online directory.
+Other passages will become highways, passed by many explorers en route to the business end of the cave bearing multiple signs of the cavers' repeated presence: ropes coiled at the bottom of a pitch, the heavily polished walls of unavoidable constrictions, a constellation of anchors on the walls of large drops.
 This guide deals with passages like these, which are often visited and give access to key areas of the cave system.
 
 ## About this Guide
 
 To assist the visiting caver unfamiliar with the complex navigation of Migovec cave system, written descriptions of key passages are given in this book, together with simplified plan view maps.
 Each double page contains both a map, with highlighted route and its corresponding description.
-The plan view maps also displays some connecting passages which may also be of interest for a short visit.
-The description of such excursions from the main route are given in *italics* in the text.
+The plan view maps also display some connecting passages which may also be of interest for a short visit.
+The descriptions of such excursions from the main route are given in *italics* in the text.
 
 ## The cave system
 
-The Tolminksi Migovec cave system is composed of three main sub-systems, known as the Old system (M2-M16-M18), Vrtnarija (also encompasses Vilinska Jama entrance), and Primadona-Mona tip (including U-bend and Belladonna entrances).
+The Tolminksi Migovec cave system is composed of three main sub-systems, known as the Old System (M2-M16-M18), Vrtnarija (also encompasses Vilinska Jama entrance), and Primadona-Monatip (including U-bend and Belladonna entrances).
 Vrtnarija connects to the Old System at the Dreams for the Soul.
-Two connections between Mona tip and the Old system are known: at Mig Country (M16) and in NCB passage (M18).
-Mona tip and Primadona are connected in several places, notably at Alkatraz and near Sejna Soba.
+Two connections between Monatip and the Old System are known: at Mig Country (M-16) and in NCB passage (M-18).
+Monatip and Primadona are connected in several places, notably at Alkatraz and near Sejna Soba.
 
 ## Access to the entrances
 
-### Primadona & Mona tip
+### Primadona & Monatip
 
-The surface abseil of Primadona begins in a shallow valley at the USTART way point. Several rebelays on a high angle grass and scree slope lead to a lip of rock next to a prominent rock spire, which is crowned by a lightning struck bush of dwarf pine. The spire overhangs the second, more vertical part of the descent: a series of rebelays landing on various rock ledges, which eventually drop by the entrance snow slope of Primadona. A traverse line leading north stops short of the Monatip entrance, which lies just around the next rocky ridge, 70 m away. Two ways into the gaping entrance of Primadona can be followed: _Drugi Vhod_ is the high level climb into a black void, while the original entrance is found at the bottom of the snow slope.
+The surface abseil of Primadona begins in a shallow valley at the USTART way point. Several rebelays on a high-angle grass and scree slope lead to a lip of rock next to a prominent rock spire, which is crowned by a lightning-struck bush of dwarf pine. The spire overhangs the second, more vertical part of the descent: a series of rebelays landing on various rock ledges, which eventually drop by the entrance snow slope of Primadona. A traverse line leading north stops short of the Monatip entrance, which lies just around the next rocky ridge, 70 m away. Two ways into the gaping entrance of Primadona can be followed: _Drugi Vhod_ is the high-level climb into a black void, while the original entrance is found at the bottom of the snow slope.
 
 ### M-16
+
 The entrance of M-16 lies close to the Bivi.
-Heading to the NE along a faint path from the top of Bivi, skirting around the opening of M-10, the way on is across a very shallow valley.
+Heading to the NE along a faint path from the top of the Bivi, skirting around the opening of M-10, the way on is across a very shallow valley.
 After cresting the far side and walking on the top surface of a wide bedding plane, a short clamber down into a deeper valley offers a view into the opening of a wide cave entrance on the left hand side (M-1).
-Heading away from this obvious entrance, a series of down-climbs leads almost immediately into a small pothole, at the bottom of which, a short clamber down gives access both a neighbouring pothole, and further down, to a dug out draughty crawl which soon leads to a window into a pitch-head (rigged).
+Heading away from this obvious entrance, a series of down-climbs leads almost immediately into a small pothole, at the bottom of which, a short clamber down gives access to both a neighbouring pothole, and further down, to a dug out draughty crawl which soon leads to a window into a pitch-head (rigged).
 This is the start of the M-16 entrance series.
 
 ### M-2
+
 From the entrance of M-1, continuing NE for approximately 100 m on the gently ascending bedding surface leads to another main crest.
-Descending beyond this crest, and keeping to the right along a contour line leads a small opening ($3\times1$ m) with a splodge of red paint (M2b) and some 40 m further, a large shakehole sometimes containing a snow plug, the main entrance of M2.
-M2 is entered by the smaller opening.
+Descending beyond this crest, and keeping to the right along a contour line leads to a small opening ($3\times1$ m) with a splodge of red paint (M-2b) and some 40 m further, a large shakehole sometimes containing a snow plug, the main entrance of M-2.
+The smaller M-2b opening is used to enter M-2.
 
 ### Vrtnarija
-Continuing downhill, NE of the M2b entrance, zig-zags are necessary to descend the inclined limestone beds. Eventually, a downclimb under a small cliff, equipped with an in-situ rope can be descended to a shallow bowl, with a rocky overhang at its NE end: underneath is the sloping, cobble floored entrance of Vrtnarija.
+
+Continuing downhill, NE of the M-2b entrance, zig-zags are necessary to descend the inclined limestone beds. Eventually, a downclimb under a small cliff, equipped with an in-situ rope can be descended to a shallow bowl, with a rocky overhang at its NE end: underneath is the sloping, cobble-floored entrance of Vrtnarija.
 
 <!-- \protect\FullWidthFigure{../outputs/Mig_routes.png}{Map of the Migovec plateau highlighting the access trails to different cave entrances}{Zemljevid planote Migovec z označenimi dostopnimi potmi do različnih jamskih vhodov}{\smalltriangle{90}} -->
 \protect\CenteredFigure{../outputs/Mig_routes.png}


### PR DESCRIPTION
I don't seem to have permission to contribute to this repo, so here's a PR from own fork 

Went through the first markdown file in the descriptions folder and tried to fix all simple errors in spelling, grammar, wording etc. that I could find